### PR TITLE
Removed offline cache files - all cache is now stored in the same place

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -40,14 +40,10 @@ meters_file = os.path.join(DATA_DIR, "input", 'meters_all.json')
 buildings_file = os.path.join(DATA_DIR, "input", 'UniHierarchy.json')
 buildings_usage_file = os.path.join(DATA_DIR, "input", 'UniHierarchyWithUsage.json')
 
-if not offlineMode:
-    meter_health_score_files = os.path.join(DATA_DIR, "cache", "meter_health_score")
-    meter_snapshots_files = os.path.join(DATA_DIR, "cache", "meter_snapshots")
-else:
-    meter_health_score_files = os.path.join(DATA_DIR, "cache", "offline_meter_health_score")
-    meter_snapshots_files = os.path.join(DATA_DIR, "cache", "offline_meter_snapshots")
+meter_health_score_files = os.path.join(DATA_DIR, "cache", "meter_health_score")
 if not os.path.exists(meter_health_score_files):
     os.makedirs(meter_health_score_files)
+meter_snapshots_files = os.path.join(DATA_DIR, "cache", "meter_snapshots")
 if not os.path.exists(meter_snapshots_files):
     os.makedirs(meter_snapshots_files)
 


### PR DESCRIPTION
I don't think that this will break anything. You will need to manually delete `./data/cache/offline_meter_health_score` and `./data/cache/meter_snapshots`. It might be worth it to also delete the online versions of these folders and regenerate the entire cache.

> [!NOTE]
> Until we have sorted out the metadata json files to always use de-anonymised ids, the cache folders will be a bit messy if you switch between online and offline modes.

Closes #130 