### PR TITLE
Check if the offline data folder exists before scanning

### DIFF
--- a/database.py
+++ b/database.py
@@ -47,6 +47,9 @@ def generate_offline_meta(write_to_db: bool = True) -> bool|dict:
     end_time = None
     interval = None
     
+    if not os.path.exists(offline_data_files):
+        return False
+    
     for file in os.listdir(offline_data_files):
         if not file.endswith(".csv"):
             continue


### PR DESCRIPTION
When initialising the database, the server scans `./data/offline` to see if there is any offline data to work with. If the `offline` folder doesn't exist a critical error is raised.

Added a check to make sure the folder exists first, before scanning.